### PR TITLE
Improve bot error reporting for key failures

### DIFF
--- a/gigachat_client.py
+++ b/gigachat_client.py
@@ -2,7 +2,9 @@ import asyncio
 import aiohttp
 import json
 import time
-from typing import Optional, Dict, Any
+import base64
+import urllib.parse
+from typing import Optional, Dict, Any, Tuple
 from config import GIGACHAT_AUTH_URL, GIGACHAT_BASE_URL, GIGACHAT_SYSTEM_PROMPT
 
 
@@ -12,12 +14,14 @@ class GigaChatClient:
         self.token_expires_at: float = 0
         self.client_secret: Optional[str] = None
         self.selected_model: str = "GigaChat-Pro"  # Модель по умолчанию
+        self.last_error_details: Optional[Dict[str, Any]] = None
         
     def set_credentials(self, client_secret: str):
         """Устанавливает учетные данные для API"""
         self.client_secret = client_secret
         self.access_token = None
         self.token_expires_at = 0
+        self.last_error_details = None
     
     def set_model(self, model_id: str):
         """Устанавливает модель для генерации"""
@@ -26,6 +30,43 @@ class GigaChatClient:
     def get_current_model(self) -> str:
         """Возвращает текущую выбранную модель"""
         return self.selected_model
+    
+    def get_last_error_details(self) -> Optional[Dict[str, Any]]:
+        """Возвращает детали последней ошибки"""
+        return self.last_error_details
+    
+    def _generate_curl_command(self, method: str, url: str, headers: Dict[str, str], data: Any = None) -> str:
+        """Генерирует curl команду для отладки"""
+        curl_parts = [f"curl -X {method}"]
+        
+        for key, value in headers.items():
+            # Маскируем чувствительные данные
+            if key.lower() == 'authorization':
+                if value.startswith('Basic '):
+                    curl_parts.append(f'-H "{key}: Basic [MASKED_BASE64_KEY]"')
+                elif value.startswith('Bearer '):
+                    curl_parts.append(f'-H "{key}: Bearer [MASKED_TOKEN]"')
+                else:
+                    curl_parts.append(f'-H "{key}: [MASKED]"')
+            else:
+                curl_parts.append(f'-H "{key}: {value}"')
+        
+        if data:
+            if isinstance(data, dict):
+                if method == 'POST' and 'Content-Type' in headers and 'form-urlencoded' in headers['Content-Type']:
+                    # Для form data
+                    form_data = []
+                    for key, value in data.items():
+                        form_data.append(f"{key}={urllib.parse.quote(str(value))}")
+                    curl_parts.append(f'--data "{" ".join(form_data)}"')
+                else:
+                    # Для JSON data
+                    curl_parts.append(f"--data '{json.dumps(data, ensure_ascii=False)}'")
+            else:
+                curl_parts.append(f'--data "{data}"')
+        
+        curl_parts.append(f'"{url}"')
+        return " \\\n  ".join(curl_parts)
     
     async def _get_access_token(self) -> str:
         """Получает access token для API"""
@@ -47,30 +88,79 @@ class GigaChatClient:
             'scope': 'GIGACHAT_API_PERS'
         }
         
-        async with aiohttp.ClientSession() as session:
-            async with session.post(
-                GIGACHAT_AUTH_URL,
-                headers=headers,
-                data=data,
-                ssl=False
-            ) as response:
-                if response.status != 200:
-                    raise Exception(f"Ошибка авторизации: {response.status}")
+        # Генерируем curl команду для диагностики
+        curl_command = self._generate_curl_command('POST', GIGACHAT_AUTH_URL, headers, data)
+        
+        self.last_error_details = {
+            'operation': 'get_access_token',
+            'url': GIGACHAT_AUTH_URL,
+            'method': 'POST',
+            'headers': {k: ('[MASKED]' if k.lower() == 'authorization' else v) for k, v in headers.items()},
+            'data': data,
+            'curl_command': curl_command,
+            'timestamp': time.time()
+        }
+        
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    GIGACHAT_AUTH_URL,
+                    headers=headers,
+                    data=data,
+                    ssl=False
+                ) as response:
+                    response_text = await response.text()
                     
-                result = await response.json()
-                self.access_token = result['access_token']
-                # Токен действует 30 минут, обновляем за 5 минут до истечения
-                self.token_expires_at = time.time() + result['expires_in'] - 300
-                
-                return self.access_token
+                    # Обновляем детали с информацией о ответе
+                    self.last_error_details.update({
+                        'response_status': response.status,
+                        'response_headers': dict(response.headers),
+                        'response_text': response_text[:1000] if len(response_text) > 1000 else response_text,
+                        'response_length': len(response_text)
+                    })
+                    
+                    if response.status != 200:
+                        error_msg = f"Ошибка авторизации: {response.status}"
+                        try:
+                            error_data = json.loads(response_text)
+                            if 'error' in error_data:
+                                error_msg += f" - {error_data['error']}"
+                            if 'error_description' in error_data:
+                                error_msg += f": {error_data['error_description']}"
+                        except:
+                            pass
+                        
+                        self.last_error_details['error'] = error_msg
+                        raise Exception(error_msg)
+                        
+                    result = json.loads(response_text)
+                    self.access_token = result['access_token']
+                    # Токен действует 30 минут, обновляем за 5 минут до истечения
+                    self.token_expires_at = time.time() + result['expires_in'] - 300
+                    
+                    # Успешная операция
+                    self.last_error_details['success'] = True
+                    self.last_error_details['token_expires_in'] = result['expires_in']
+                    
+                    return self.access_token
+        except aiohttp.ClientError as e:
+            self.last_error_details['error'] = f"Ошибка соединения: {str(e)}"
+            raise Exception(f"Ошибка соединения: {str(e)}")
+        except json.JSONDecodeError as e:
+            self.last_error_details['error'] = f"Ошибка парсинга JSON: {str(e)}"
+            raise Exception(f"Ошибка парсинга ответа: {str(e)}")
+        except Exception as e:
+            if 'error' not in self.last_error_details:
+                self.last_error_details['error'] = str(e)
+            raise
     
-    async def check_credentials(self) -> bool:
-        """Проверяет валидность учетных данных"""
+    async def check_credentials(self) -> Tuple[bool, Optional[str]]:
+        """Проверяет валидность учетных данных. Возвращает (is_valid, error_message)"""
         try:
             await self._get_access_token()
-            return True
-        except Exception:
-            return False
+            return True, None
+        except Exception as e:
+            return False, str(e)
     
     async def get_available_models(self) -> list:
         """Получает список доступных моделей"""
@@ -84,42 +174,82 @@ class GigaChatClient:
             'Authorization': f'Bearer {access_token}'
         }
         
-        async with aiohttp.ClientSession() as session:
-            async with session.get(
-                f"{GIGACHAT_BASE_URL}/models",
-                headers=headers,
-                ssl=False
-            ) as response:
-                if response.status != 200:
-                    # Если API не поддерживает /models, возвращаем известные модели
-                    return [
-                        {"id": "GigaChat", "description": "Базовая модель GigaChat"},
-                        {"id": "GigaChat-Pro", "description": "Продвинутая модель GigaChat-Pro"},
-                        {"id": "GigaChat-Max", "description": "Максимальная модель GigaChat-Max"}
-                    ]
+        # Генерируем curl команду для диагностики
+        curl_command = self._generate_curl_command('GET', f"{GIGACHAT_BASE_URL}/models", headers)
+        
+        self.last_error_details = {
+            'operation': 'get_available_models',
+            'url': f"{GIGACHAT_BASE_URL}/models",
+            'method': 'GET',
+            'headers': {k: ('[MASKED]' if k.lower() == 'authorization' else v) for k, v in headers.items()},
+            'curl_command': curl_command,
+            'timestamp': time.time()
+        }
+        
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(
+                    f"{GIGACHAT_BASE_URL}/models",
+                    headers=headers,
+                    ssl=False
+                ) as response:
+                    response_text = await response.text()
                     
-                result = await response.json()
-                
-                if 'data' in result:
-                    return [
-                        {
-                            "id": model.get("id", "Unknown"),
-                            "description": model.get("id", "Unknown") + (
-                                " (Pro версия)" if "Pro" in model.get("id", "") else
-                                " (Max версия)" if "Max" in model.get("id", "") else
-                                " (Базовая версия)"
-                            )
-                        }
-                        for model in result['data']
-                        if model.get("id", "").startswith("GigaChat")
-                    ]
-                else:
-                    # Фолбэк к известным моделям
-                    return [
-                        {"id": "GigaChat", "description": "Базовая модель GigaChat"},
-                        {"id": "GigaChat-Pro", "description": "Продвинутая модель GigaChat-Pro"},
-                        {"id": "GigaChat-Max", "description": "Максимальная модель GigaChat-Max"}
-                    ]
+                    # Обновляем детали с информацией о ответе
+                    self.last_error_details.update({
+                        'response_status': response.status,
+                        'response_headers': dict(response.headers),
+                        'response_text': response_text[:1000] if len(response_text) > 1000 else response_text,
+                        'response_length': len(response_text)
+                    })
+                    
+                    if response.status != 200:
+                        # Если API не поддерживает /models, возвращаем известные модели
+                        self.last_error_details['fallback_to_default'] = True
+                        return [
+                            {"id": "GigaChat", "description": "Базовая модель GigaChat"},
+                            {"id": "GigaChat-Pro", "description": "Продвинутая модель GigaChat-Pro"},
+                            {"id": "GigaChat-Max", "description": "Максимальная модель GigaChat-Max"}
+                        ]
+                        
+                    result = json.loads(response_text)
+                    
+                    # Успешная операция
+                    self.last_error_details['success'] = True
+                    
+                    if 'data' in result:
+                        models = [
+                            {
+                                "id": model.get("id", "Unknown"),
+                                "description": model.get("id", "Unknown") + (
+                                    " (Pro версия)" if "Pro" in model.get("id", "") else
+                                    " (Max версия)" if "Max" in model.get("id", "") else
+                                    " (Базовая версия)"
+                                )
+                            }
+                            for model in result['data']
+                            if model.get("id", "").startswith("GigaChat")
+                        ]
+                        self.last_error_details['models_count'] = len(models)
+                        return models
+                    else:
+                        # Фолбэк к известным моделям
+                        self.last_error_details['fallback_to_default'] = True
+                        return [
+                            {"id": "GigaChat", "description": "Базовая модель GigaChat"},
+                            {"id": "GigaChat-Pro", "description": "Продвинутая модель GigaChat-Pro"},
+                            {"id": "GigaChat-Max", "description": "Максимальная модель GigaChat-Max"}
+                        ]
+        except aiohttp.ClientError as e:
+            self.last_error_details['error'] = f"Ошибка соединения: {str(e)}"
+            raise Exception(f"Ошибка соединения: {str(e)}")
+        except json.JSONDecodeError as e:
+            self.last_error_details['error'] = f"Ошибка парсинга JSON: {str(e)}"
+            raise Exception(f"Ошибка парсинга ответа: {str(e)}")
+        except Exception as e:
+            if 'error' not in self.last_error_details:
+                self.last_error_details['error'] = str(e)
+            raise
     
     async def generate_diagram_code(self, user_request: str) -> str:
         """Генерирует код диаграммы на основе запроса пользователя"""
@@ -150,36 +280,84 @@ class GigaChatClient:
             "temperature": 0.1
         }
         
-        async with aiohttp.ClientSession() as session:
-            async with session.post(
-                f"{GIGACHAT_BASE_URL}/chat/completions",
-                headers=headers,
-                json=payload,
-                ssl=False
-            ) as response:
-                if response.status != 200:
-                    raise Exception(f"Ошибка API: {response.status}")
+        # Генерируем curl команду для диагностики
+        curl_command = self._generate_curl_command('POST', f"{GIGACHAT_BASE_URL}/chat/completions", headers, payload)
+        
+        self.last_error_details = {
+            'operation': 'generate_diagram_code',
+            'url': f"{GIGACHAT_BASE_URL}/chat/completions",
+            'method': 'POST',
+            'headers': {k: ('[MASKED]' if k.lower() == 'authorization' else v) for k, v in headers.items()},
+            'payload': payload,
+            'curl_command': curl_command,
+            'timestamp': time.time()
+        }
+        
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{GIGACHAT_BASE_URL}/chat/completions",
+                    headers=headers,
+                    json=payload,
+                    ssl=False
+                ) as response:
+                    response_text = await response.text()
                     
-                result = await response.json()
-                
-                if 'choices' not in result or not result['choices']:
-                    raise Exception("Пустой ответ от API")
+                    # Обновляем детали с информацией о ответе
+                    self.last_error_details.update({
+                        'response_status': response.status,
+                        'response_headers': dict(response.headers),
+                        'response_text': response_text[:1000] if len(response_text) > 1000 else response_text,
+                        'response_length': len(response_text)
+                    })
                     
-                content = result['choices'][0]['message']['content']
-                
-                # Извлекаем код из markdown блока
-                if '```python' in content:
-                    code_start = content.find('```python') + 9
-                    code_end = content.find('```', code_start)
-                    if code_end != -1:
-                        return content[code_start:code_end].strip()
-                elif '```' in content:
-                    code_start = content.find('```') + 3
-                    code_end = content.find('```', code_start)
-                    if code_end != -1:
-                        return content[code_start:code_end].strip()
-                
-                return content.strip()
+                    if response.status != 200:
+                        error_msg = f"Ошибка API: {response.status}"
+                        try:
+                            error_data = json.loads(response_text)
+                            if 'error' in error_data:
+                                error_msg += f" - {error_data['error']}"
+                        except:
+                            pass
+                        
+                        self.last_error_details['error'] = error_msg
+                        raise Exception(error_msg)
+                        
+                    result = json.loads(response_text)
+                    
+                    if 'choices' not in result or not result['choices']:
+                        self.last_error_details['error'] = "Пустой ответ от API"
+                        raise Exception("Пустой ответ от API")
+                        
+                    content = result['choices'][0]['message']['content']
+                    
+                    # Успешная операция
+                    self.last_error_details['success'] = True
+                    self.last_error_details['response_content_length'] = len(content)
+                    
+                    # Извлекаем код из markdown блока
+                    if '```python' in content:
+                        code_start = content.find('```python') + 9
+                        code_end = content.find('```', code_start)
+                        if code_end != -1:
+                            return content[code_start:code_end].strip()
+                    elif '```' in content:
+                        code_start = content.find('```') + 3
+                        code_end = content.find('```', code_start)
+                        if code_end != -1:
+                            return content[code_start:code_end].strip()
+                    
+                    return content.strip()
+        except aiohttp.ClientError as e:
+            self.last_error_details['error'] = f"Ошибка соединения: {str(e)}"
+            raise Exception(f"Ошибка соединения: {str(e)}")
+        except json.JSONDecodeError as e:
+            self.last_error_details['error'] = f"Ошибка парсинга JSON: {str(e)}"
+            raise Exception(f"Ошибка парсинга ответа: {str(e)}")
+        except Exception as e:
+            if 'error' not in self.last_error_details:
+                self.last_error_details['error'] = str(e)
+            raise
 
 
 # Глобальный экземпляр клиента

--- a/main.py
+++ b/main.py
@@ -50,6 +50,64 @@ def get_main_keyboard():
     return keyboard
 
 
+def format_error_details(error_details: dict, show_sensitive=False) -> str:
+    """Форматирует детали ошибки для показа пользователю"""
+    if not error_details:
+        return "Детали ошибки недоступны"
+    
+    result = []
+    
+    # Основная информация
+    result.append(f"🔍 **Диагностика запроса**\n")
+    result.append(f"**Операция:** {error_details.get('operation', 'неизвестно')}")
+    result.append(f"**URL:** `{error_details.get('url', 'неизвестно')}`")
+    result.append(f"**Метод:** {error_details.get('method', 'неизвестно')}")
+    
+    # Заголовки
+    if 'headers' in error_details:
+        result.append(f"\n**Заголовки запроса:**")
+        for key, value in error_details['headers'].items():
+            result.append(f"• `{key}: {value}`")
+    
+    # Данные запроса
+    if 'data' in error_details:
+        result.append(f"\n**Данные запроса:**")
+        for key, value in error_details['data'].items():
+            result.append(f"• `{key}: {value}`")
+    
+    # Информация о ответе
+    if 'response_status' in error_details:
+        result.append(f"\n**Ответ сервера:**")
+        result.append(f"**Статус:** {error_details['response_status']}")
+        
+        if 'response_headers' in error_details:
+            result.append(f"**Заголовки ответа:**")
+            for key, value in list(error_details['response_headers'].items())[:5]:  # Показываем только первые 5
+                result.append(f"• `{key}: {value}`")
+        
+        if 'response_text' in error_details:
+            response_text = error_details['response_text']
+            if len(response_text) > 500:
+                response_text = response_text[:500] + "..."
+            result.append(f"**Текст ответа:**\n```\n{response_text}\n```")
+    
+    # Curl команда
+    if 'curl_command' in error_details:
+        result.append(f"\n**Эквивалентная curl команда:**\n```bash\n{error_details['curl_command']}\n```")
+    
+    # Ошибка
+    if 'error' in error_details:
+        result.append(f"\n❌ **Ошибка:** {error_details['error']}")
+    
+    # Успех
+    if error_details.get('success'):
+        result.append(f"\n✅ **Запрос выполнен успешно**")
+        if 'token_expires_in' in error_details:
+            result.append(f"• Токен действует: {error_details['token_expires_in']} секунд")
+    
+    return "\n".join(result)
+
+
 @dp.message(Command("start"))
 async def start_command(message: types.Message):
     """Обработчик команды /start"""
@@ -121,6 +179,139 @@ async def create_diagram_callback(callback: types.CallbackQuery, state: FSMConte
     await state.set_state(UserStates.waiting_diagram_request)
 
 
+@dp.callback_query(F.data == "select_model")
+async def select_model_callback(callback: types.CallbackQuery, state: FSMContext):
+    """Обработчик выбора модели"""
+    user_id = callback.from_user.id
+    
+    if user_id not in user_api_keys:
+        await callback.message.edit_text(
+            "❌ **API ключ не установлен**\n\n"
+            "Для выбора модели необходимо установить API ключ Гигачата.\n"
+            "Нажмите кнопку ниже для установки ключа.",
+            reply_markup=get_main_keyboard(),
+            parse_mode="Markdown"
+        )
+        return
+    
+    # Устанавливаем API ключ для текущего запроса
+    gigachat_client.set_credentials(user_api_keys[user_id])
+    
+    status_message = await callback.message.edit_text("🔄 Получаю список доступных моделей...")
+    
+    try:
+        models = await gigachat_client.get_available_models()
+        current_model = gigachat_client.get_current_model()
+        
+        if models:
+            model_buttons = []
+            for model in models:
+                model_id = model["id"]
+                model_desc = model["description"]
+                
+                # Добавляем галочку для текущей модели
+                button_text = f"✅ {model_desc}" if model_id == current_model else model_desc
+                model_buttons.append([InlineKeyboardButton(
+                    text=button_text, 
+                    callback_data=f"model_{model_id}"
+                )])
+            
+            # Добавляем кнопку возврата
+            model_buttons.append([InlineKeyboardButton(text="🔙 Назад", callback_data="back_to_main")])
+            
+            keyboard = InlineKeyboardMarkup(inline_keyboard=model_buttons)
+            
+            await status_message.edit_text(
+                f"🤖 **Выбор модели**\n\n"
+                f"**Текущая модель:** {current_model}\n\n"
+                f"Выберите модель для генерации диаграмм:",
+                reply_markup=keyboard,
+                parse_mode="Markdown"
+            )
+        else:
+            await status_message.edit_text(
+                "❌ **Не удалось получить список моделей**\n\n"
+                "Используется модель по умолчанию: GigaChat-Pro",
+                reply_markup=get_main_keyboard(),
+                parse_mode="Markdown"
+            )
+            
+    except Exception as e:
+        logger.error(f"Ошибка получения моделей: {e}")
+        
+        # Получаем детали ошибки для диагностики
+        error_details = gigachat_client.get_last_error_details()
+        
+        error_text = "❌ **Ошибка получения моделей**\n\n"
+        error_text += f"**Ошибка:** {str(e)}\n\n"
+        
+        if error_details and not error_details.get('success', False):
+            error_text += "**📋 Детали запроса к API:**\n"
+            error_text += format_error_details(error_details)
+        
+        # Если сообщение слишком длинное, разбиваем на части
+        if len(error_text) > 4000:
+            await status_message.edit_text(
+                "❌ **Ошибка получения моделей**\n\n"
+                f"**Ошибка:** {str(e)}\n\n"
+                "Отправляю подробную диагностику...",
+                parse_mode="Markdown"
+            )
+            
+            if error_details and not error_details.get('success', False):
+                await callback.message.answer(
+                    "**📋 Детали запроса к API:**\n" + format_error_details(error_details),
+                    parse_mode="Markdown"
+                )
+            
+            await callback.message.answer(
+                "Используется модель по умолчанию: GigaChat-Pro",
+                reply_markup=get_main_keyboard()
+            )
+        else:
+            await status_message.edit_text(
+                error_text + "\n\nИспользуется модель по умолчанию: GigaChat-Pro",
+                reply_markup=get_main_keyboard(),
+                parse_mode="Markdown"
+            )
+
+
+@dp.callback_query(F.data.startswith("model_"))
+async def model_selected_callback(callback: types.CallbackQuery):
+    """Обработчик выбора конкретной модели"""
+    model_id = callback.data.replace("model_", "")
+    user_id = callback.from_user.id
+    
+    if user_id in user_api_keys:
+        gigachat_client.set_credentials(user_api_keys[user_id])
+        gigachat_client.set_model(model_id)
+        user_models[user_id] = model_id
+        
+        await callback.message.edit_text(
+            f"✅ **Модель выбрана!**\n\n"
+            f"**Активная модель:** {model_id}\n\n"
+            f"Теперь диаграммы будут создаваться с использованием этой модели.",
+            reply_markup=get_main_keyboard(),
+            parse_mode="Markdown"
+        )
+    else:
+        await callback.message.edit_text(
+            "❌ API ключ не найден. Установите ключ заново.",
+            reply_markup=get_main_keyboard()
+        )
+
+
+@dp.callback_query(F.data == "back_to_main")
+async def back_to_main_callback(callback: types.CallbackQuery):
+    """Обработчик возврата в главное меню"""
+    await callback.message.edit_text(
+        "🏠 **Главное меню**\n\n"
+        "Выберите действие:",
+        reply_markup=get_main_keyboard(),
+        parse_mode="Markdown"
+    )
+
+
 @dp.callback_query(F.data == "help")
 async def help_callback(callback: types.CallbackQuery):
     """Обработчик помощи"""
@@ -177,7 +368,7 @@ async def process_api_key(message: types.Message, state: FSMContext):
     
     try:
         gigachat_client.set_credentials(api_key)
-        is_valid = await gigachat_client.check_credentials()
+        is_valid, error_message = await gigachat_client.check_credentials()
         
         if is_valid:
             user_api_keys[user_id] = api_key
@@ -189,20 +380,90 @@ async def process_api_key(message: types.Message, state: FSMContext):
                 parse_mode="Markdown"
             )
         else:
+            # Получаем детали ошибки
+            error_details = gigachat_client.get_last_error_details()
+            
+            error_text = "❌ **Неверный API ключ**\n\n"
+            
+            if error_message:
+                error_text += f"**Ошибка:** {error_message}\n\n"
+            
+            if error_details:
+                error_text += format_error_details(error_details)
+                error_text += "\n\n**💡 Рекомендации:**\n"
+                error_text += "• Проверьте правильность API ключа\n"
+                error_text += "• Убедитесь, что ключ активен\n"
+                error_text += "• Проверьте права доступа к API\n"
+                error_text += "• Сравните с запросом в Postman"
+            else:
+                error_text += "Проверьте правильность ключа и попробуйте снова."
+            
+            # Если сообщение слишком длинное, разбиваем на части
+            if len(error_text) > 4000:
+                await status_message.edit_text(
+                    "❌ **Неверный API ключ**\n\n"
+                    f"**Ошибка:** {error_message}\n\n"
+                    "Отправляю подробную диагностику...",
+                    parse_mode="Markdown"
+                )
+                
+                await message.answer(
+                    format_error_details(error_details),
+                    parse_mode="Markdown"
+                )
+                
+                await message.answer(
+                    "**💡 Рекомендации:**\n"
+                    "• Проверьте правильность API ключа\n"
+                    "• Убедитесь, что ключ активен\n"
+                    "• Проверьте права доступа к API\n"
+                    "• Сравните с запросом в Postman",
+                    reply_markup=get_main_keyboard(),
+                    parse_mode="Markdown"
+                )
+            else:
+                await status_message.edit_text(
+                    error_text,
+                    reply_markup=get_main_keyboard(),
+                    parse_mode="Markdown"
+                )
+    except Exception as e:
+        logger.error(f"Ошибка проверки API ключа: {e}")
+        
+        # Получаем детали ошибки для диагностики
+        error_details = gigachat_client.get_last_error_details()
+        
+        error_text = "❌ **Ошибка проверки API ключа**\n\n"
+        error_text += f"**Ошибка:** {str(e)}\n\n"
+        
+        if error_details:
+            error_text += format_error_details(error_details)
+        
+        # Если сообщение слишком длинное, разбиваем на части
+        if len(error_text) > 4000:
             await status_message.edit_text(
-                "❌ **Неверный API ключ**\n\n"
-                "Проверьте правильность ключа и попробуйте снова.",
+                "❌ **Ошибка проверки API ключа**\n\n"
+                f"**Ошибка:** {str(e)}\n\n"
+                "Отправляю подробную диагностику...",
+                parse_mode="Markdown"
+            )
+            
+            if error_details:
+                await message.answer(
+                    format_error_details(error_details),
+                    parse_mode="Markdown"
+                )
+            
+            await message.answer(
+                "Попробуйте позже или обратитесь к администратору.",
+                reply_markup=get_main_keyboard()
+            )
+        else:
+            await status_message.edit_text(
+                error_text,
                 reply_markup=get_main_keyboard(),
                 parse_mode="Markdown"
             )
-    except Exception as e:
-        logger.error(f"Ошибка проверки API ключа: {e}")
-        await status_message.edit_text(
-            "❌ **Ошибка проверки API ключа**\n\n"
-            "Произошла ошибка при проверке ключа. Попробуйте позже.",
-            reply_markup=get_main_keyboard(),
-            parse_mode="Markdown"
-        )
     
     await state.clear()
 
@@ -271,13 +532,52 @@ async def process_diagram_request(message: types.Message, state: FSMContext):
             
     except Exception as e:
         logger.error(f"Ошибка создания диаграммы: {e}")
-        await status_message.edit_text(
-            f"❌ **Ошибка создания диаграммы**\n\n"
-            f"Произошла ошибка: {str(e)}\n\n"
-            f"Попробуйте изменить запрос или попробовать позже.",
-            reply_markup=get_main_keyboard(),
-            parse_mode="Markdown"
-        )
+        
+        # Получаем детали ошибки для диагностики
+        error_details = gigachat_client.get_last_error_details()
+        
+        error_text = f"❌ **Ошибка создания диаграммы**\n\n"
+        error_text += f"**Ошибка:** {str(e)}\n\n"
+        
+        if error_details:
+            if not error_details.get('success', False):
+                error_text += "**📋 Детали запроса к API:**\n"
+                error_text += format_error_details(error_details)
+        
+        error_text += "\n**💡 Попробуйте:**\n"
+        error_text += "• Изменить формулировку запроса\n"
+        error_text += "• Использовать более простое описание\n"
+        error_text += "• Повторить попытку позже"
+        
+        # Если сообщение слишком длинное, разбиваем на части
+        if len(error_text) > 4000:
+            await status_message.edit_text(
+                f"❌ **Ошибка создания диаграммы**\n\n"
+                f"**Ошибка:** {str(e)}\n\n"
+                "Отправляю подробную диагностику...",
+                parse_mode="Markdown"
+            )
+            
+            if error_details and not error_details.get('success', False):
+                await message.answer(
+                    "**📋 Детали запроса к API:**\n" + format_error_details(error_details),
+                    parse_mode="Markdown"
+                )
+            
+            await message.answer(
+                "**💡 Попробуйте:**\n"
+                "• Изменить формулировку запроса\n"
+                "• Использовать более простое описание\n"
+                "• Повторить попытку позже",
+                reply_markup=get_main_keyboard(),
+                parse_mode="Markdown"
+            )
+        else:
+            await status_message.edit_text(
+                error_text,
+                reply_markup=get_main_keyboard(),
+                parse_mode="Markdown"
+            )
     
     await state.clear()
 


### PR DESCRIPTION
Implement detailed API request diagnostics, including curl commands, to aid in debugging Gigachat key issues.

This addresses the user's request to get more detailed information when the Gigachat API key fails in the bot, especially when it works in tools like Postman. The added diagnostics, including the `curl` command, help in comparing the bot's request with a working one.